### PR TITLE
fix: try on: pull_request_target to share secrets with fork instead of on: pull_request

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,37 +34,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Test secret access
-        run: |
-          if [[ "${{ env.SUPER_SECRET }}" == "" ]]; then
-            echo "No access to secrets"
-            exit 1
-          else
-            echo "Access to secrets!"
-          fi
+        if: env.SUPER_SECRET == ''
+        run: 
+          echo "No access to secrets"
+          exit 1
 
-  checkout-test-merge-commit:
-    needs: verify-user-permissions
-    name: Checkout action using merge commit sha ref
-    runs-on: ubuntu-latest
-    env:
-      SUPER_SECRET: ${{ secrets.SUPER_SECRET }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.merge_commit_sha }}
-
-      - name: Test secret access
-        run: |
-          if [[ "${{ env.SUPER_SECRET }}" == "" ]]; then
-            echo "No access to secrets"
-            exit 1
-          else
-            echo "Access to secrets!"
-          fi
-
-
+      - name: Secret access!
+        run: echo "Access to secrets!"
 
 
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 jobs:


### PR DESCRIPTION
`on: pull_request_target` allows the sharing of secrets with forks, and it should be used with a safeguard, such as checking the permissions of the triggering actor, as we do here.

`on: pull_request` will not share secrets with forks, even if triggering actor has write permissions, as seen with this PR: https://github.com/momentohq/ci-testing/pull/6 

Also did some minor cleanup of the workflow file:

- Determined that the default ref used by `checkout` action is fine, removed the second block with non-default ref
- Use `if` condition in github actions syntax to avoid printing out the secret when checking if it exists